### PR TITLE
Use "-" instead of "[]"

### DIFF
--- a/.github/workflows/test1.yaml
+++ b/.github/workflows/test1.yaml
@@ -1,7 +1,9 @@
 name: noed_env
 on: 
   push:
-    branches-ignore: [ $default-branch ]
+    # branches-ignore: [ $default-branch ]
+    branches-ignore:
+      - $default-branch
 jobs:
   build:
    runs-on: ubuntu-latest


### PR DESCRIPTION
"main" と指定するところを "master" にしていてジョブが重複していたのでテストしている最中。
(ブランチ名以外にも `branches-ignore` を `branches_ignore` にしてたりとの問題もあったが)

"master" に間違えると問題もありそうなので「デフォルトブランチ名」で指定する方法がないか調べてみたら以下がヒットした。
https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable
https://github.blog/changelog/2020-07-22-github-actions-better-support-for-alternative-default-branch-names/

で、以下のようにすると `$ gh merge -m -d` で除外されない。
```yaml
on:
  push:
    branches-ignore:
      - $default-branch
```

が、以下のようにすると除外される。
```yaml
 on:
   push:
     branches-ignore: [ $default-branch ]
```


ということで、もういちど以下で再チェック。
```yaml
on: 
  push:
    # branches-ignore: [ $default-branch ]
    branches-ignore:
      - $default-branch
```

そもそも「macro」って何状態ではあるのだけど。
> We have updated all of our starter workflows to use a new $default-branch macro rather than the previously hardcoded master. You can take advantage of this feature in your custom starter workflow templates as well.

「github actions macro」で検索しても上のブログ記事と「$default-branch」についてのやりとりが出てくるくらい。
https://github.community/t/access-default-branch-macro-inside-action/160685
